### PR TITLE
Areas container with data

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/user-event": "^7.2.1",
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.1.2",

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import logo from './logo.svg';
 import './App.css';
 import UserLogin from '../src/components/Login/login.js';
 import AreasContainer from '../src/components/AreasContainer/AreasContainer.js';
-import { Switch, Route, Redirect } from 'react-router-dom';
+import { Switch, Route } from 'react-router-dom';
 import { Component } from 'react';
 
 
@@ -63,7 +62,7 @@ export default class App extends Component {
     return (
       <main>
        <Switch>
-         <Route path="/areas" render={ () => <AreasContainer/>}/>
+         <Route path="/areas" render={ () => <AreasContainer />}/>
          <Route path='/' render={ () => <UserLogin setUserInfo={this.setUserInfo} />}/>
        </Switch>
       </main>

--- a/src/App.js
+++ b/src/App.js
@@ -62,8 +62,8 @@ export default class App extends Component {
     return (
       <main>
        <Switch>
-         <Route path="/areas" render={ () => <AreasContainer />}/>
-         <Route path='/' render={ () => <UserLogin setUserInfo={this.setUserInfo} />}/>
+        <Route path="/areas" render={ () => <AreasContainer listingsByArea={this.state.listingsByArea} />}/>
+        <Route path='/' render={ () => <UserLogin setUserInfo={this.setUserInfo} />}/>
        </Switch>
       </main>
     )

--- a/src/components/Areas/Areas.css
+++ b/src/components/Areas/Areas.css
@@ -1,0 +1,10 @@
+/* STYLING FOR AREA CARDS */
+.area-card {
+  border-radius: 4px;
+  box-shadow: 4px 3px 3px 3px rgba(0, 0, 0, 0.08);
+  height: 40%;
+  margin-bottom: 2%;
+  text-align: center;
+  padding: 0 1%;
+  width: 40%;
+}

--- a/src/components/Areas/Areas.js
+++ b/src/components/Areas/Areas.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import './Areas.css';
+
+const Areas = (props) => {
+  return (
+    <section>
+      <h3>&ldquo;{props.areaNickname}&rdquo;</h3>
+      <h4>{props.name}</h4>
+      <p>{props.location}</p>
+      <p>{props.about}</p>
+      <button>View Listings</button>
+    </section>
+  )
+}
+
+
+export default Areas;

--- a/src/components/Areas/Areas.js
+++ b/src/components/Areas/Areas.js
@@ -4,7 +4,7 @@ import './Areas.css';
 
 const Areas = (props) => {
   return (
-    <section>
+    <section className='area-card'>
       <h3>&ldquo;{props.areaNickname}&rdquo;</h3>
       <h4>{props.name}</h4>
       <p>{props.location}</p>

--- a/src/components/Areas/Areas.js
+++ b/src/components/Areas/Areas.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import './Areas.css';
 
 const Areas = (props) => {
@@ -13,5 +14,12 @@ const Areas = (props) => {
   )
 }
 
-
 export default Areas;
+
+Areas.propTypes = {
+  key: PropTypes.number,
+  areaNickname: PropTypes.string,
+  name: PropTypes.string,
+  location: PropTypes.string,
+  about: PropTypes.string
+};

--- a/src/components/Areas/Areas.test.js
+++ b/src/components/Areas/Areas.test.js
@@ -1,0 +1,8 @@
+import React from 'React';
+import { render } from '@testing-library/react';
+
+describe('Areas', () => {
+  it('should render area cards to the page', ()=> {
+
+  });
+});

--- a/src/components/AreasContainer/AreasContainer.css
+++ b/src/components/AreasContainer/AreasContainer.css
@@ -1,1 +1,16 @@
 /* STYLING FOR AREAS CONTAINER */
+.areas-container {
+  display: grid;
+  grid-template-columns: 20% 80%;
+  grid-template-rows: 100vh;
+  grid-template-areas:
+  "user-profile card-container"
+}
+
+.card-container {
+  display: flex;
+  flex-wrap: wrap;
+  grid-area: card-container;
+  justify-content: space-around;
+  padding-top: 5%;
+}

--- a/src/components/AreasContainer/AreasContainer.js
+++ b/src/components/AreasContainer/AreasContainer.js
@@ -1,14 +1,11 @@
-import React from 'react';
+import React from 'react'
+import Areas from '../../components/Areas/Areas.js'
+import PropTypes from 'prop-types';
 import './AreasContainer.css';
 
 const AreasContainer = (props) => {
   const allAreas = props.listingsByArea.map(area => {
-    // console.log(area[0].areaNickname);
-    // console.log(area[0].areaDetails.name);
-    // console.log(area[0].areaDetails.location);
-    // console.log(area[0].areaDetails.about);
-    // console.log(area[0].areaDetails.id);
-    return <Area
+    return <Areas
       key={area[0].areaDetails.id}
       areaNickname={area[0].areaNickname}
       name={area[0].areaDetails.name}
@@ -25,3 +22,11 @@ const AreasContainer = (props) => {
 }
 
 export default AreasContainer;
+
+AreasContainer.propTypes = {
+  key: PropTypes.number,
+  areaNickname: PropTypes.string,
+  name: PropTypes.string,
+  location: PropTypes.string,
+  about: PropTypes.string
+};

--- a/src/components/AreasContainer/AreasContainer.js
+++ b/src/components/AreasContainer/AreasContainer.js
@@ -15,8 +15,10 @@ const AreasContainer = (props) => {
   })
 
   return (
-    <section>
+    <section className='areas-container'>
+      <section className='card-container'>
       { allAreas }
+      </section>
     </section>
   )
 }

--- a/src/components/AreasContainer/AreasContainer.js
+++ b/src/components/AreasContainer/AreasContainer.js
@@ -1,20 +1,25 @@
 import React from 'react';
 import './AreasContainer.css';
 
-const AreasContainer = () => {
-  // const allAreas = props.map(area => {
-  //   return <Area
-  //     name={area.area}
-  //     location={area.location}
-  //     about={area.about}
-  //     listings-{area.listings}
-  //     key={area.id}
-  //   />
-  // })
+const AreasContainer = (props) => {
+  const allAreas = props.listingsByArea.map(area => {
+    // console.log(area[0].areaNickname);
+    // console.log(area[0].areaDetails.name);
+    // console.log(area[0].areaDetails.location);
+    // console.log(area[0].areaDetails.about);
+    // console.log(area[0].areaDetails.id);
+    return <Area
+      key={area[0].areaDetails.id}
+      areaNickname={area[0].areaNickname}
+      name={area[0].areaDetails.name}
+      location={area[0].areaDetails.location}
+      about={area[0].areaDetails.about}
+    />
+  })
 
   return (
     <section>
-      <h1>made it</h1>
+      { allAreas }
     </section>
   )
 }

--- a/src/components/Login/login.js
+++ b/src/components/Login/login.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
-import AreasContainer from '/Users/trondmakonese/mod_3/V-RAD/v-rad-project/src/components/AreasContainer/AreasContainer.js';
 import { Link } from 'react-router-dom';
-import '/Users/trondmakonese/mod_3/V-RAD/v-rad-project/src/components/Login/login.css'
+
 
 
 


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing
- [X] Styling

### Detailed Description
I used the the data received from the fetch API as props for the area container and for the area cards. I also began to style the area cards. No functionality has been added to the View Listings button.

I also added installed and used the PropTypes library to typecheck the props being passed into AreasContainer and Areas. So far, so good...

### Why is this change required? What problem does it solve?
The user is now able to visually see the areas of interest.

### Were there any challenges that arose while implementing this feature? If so, how were the addressed?
The data is set up a bit weird in the App's state, but it is possible to get to it. We can always go back and modify how the data is being set up in state.

### Files modified:
- [ ] src/components/App
- [ ] src/components/UserLogin
- [ ] src/components/UserProfile
- [ ] src/components/MainContainer
- [X] src/components/AreasContainer
- [X] src/components/AreasCard
- [ ] src/components/ListingsContainer
- [ ] src/components/ListingsCard
- [ ] Other files:
